### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-boxcars = "0.9.3"
+boxcars = "0.10.3"
 log = "0.4.14"
 simplelog = "0.11.2"
 lazy_static = "1.4.0"
@@ -21,10 +21,6 @@ nalgebra = "0.18.1"
 thiserror = "1.0.30"
 structopt = "0.3.22"
 clap = "2.33.3"
-
-[dependencies.pyo3]
-version = "0.14.1"
-features = ["auto-initialize"]
 
 [dev-dependencies]
 criterion = "0.3.4"


### PR DESCRIPTION
PyO3 is not needed and boxcars is outdated.